### PR TITLE
Dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "io.zbejas.ping"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     mavenCentral()
@@ -18,4 +18,10 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.processResources {
+    filesMatching("manifest.json") {
+        expand("version" to project.version)
+    }
 }

--- a/src/main/java/io/zbejas/ping/events/PacketListener.java
+++ b/src/main/java/io/zbejas/ping/events/PacketListener.java
@@ -48,10 +48,6 @@ public class PacketListener implements PacketWatcher {
         }
 
         UUID uuid = playerAuth.getUuid();
-        if (uuid == null) {
-            return;
-        }
-
         PlayerRef player = Universe.get().getPlayer(uuid);
         if (player == null) {
             return;

--- a/src/main/java/io/zbejas/ping/service/PingService.java
+++ b/src/main/java/io/zbejas/ping/service/PingService.java
@@ -104,11 +104,6 @@ public class PingService {
             return;
         }
 
-        if (transform == null) {
-            logger.debugPlayer(player, "Could not get player transform");
-            return;
-        }
-
         Vector3d eyePosition = calculateEyePosition(transform.getPosition());
         Vector3d lookDirection = getLookDirection(player, transform);
 

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "Group": "Zbejas",
   "Name": "Ping",
-  "Version": "1.0.0",
+  "Version": "${version}",
   "Main": "io.zbejas.ping.Main",
   "Description": "Ping any place nearby to show people around what you are looking at.",
   "Authors": [
@@ -11,7 +11,7 @@
       "Url": "https://zbejas.io"
     }
   ],
-  "Website": "https://zbejas.io/projects/ping",
+  "Website": "https://www.curseforge.com/hytale/mods/ping",
   "ServerVersion": "*",
   "Dependencies": {},
   "OptionalDependencies": {},


### PR DESCRIPTION
Manifest updates:

* Updated the `Version` field in `manifest.json` to use the `${version}` placeholder, allowing for dynamic versioning during builds.
* Changed the `Website` field in `manifest.json` to point to the project's CurseForge page instead of the previous URL.

Java code simplification:

* Removed the null check for `uuid` in `PacketListener.java`'s `accept` method, likely because the code now guarantees `uuid` is never null at this point.
* Removed the null check and debug logging for `transform` in `PingService.java`'s `handlePickInteractionOnWorldThread` method, possibly due to improved upstream validation or guarantees.